### PR TITLE
Add URL to upstream master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # usbids
-Linux USB ID Repository (master still in CVS at SourceForge.net)
+Linux USB ID Repository [(master still in CVS at SourceForge.net)](https://sourceforge.net/p/linux-usb/repo/HEAD/tree/trunk/htdocs/usb.ids)


### PR DESCRIPTION
It is very helpful to have the actual URL to the upstream master,
as reported in the README.md file.